### PR TITLE
Make Display farmer work if the url is loaded for the first time

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -50,11 +50,10 @@ function App() {
   const loadFarmers = () => {
     getFarmersHandler()
       .then(retrievedFarmers => {
-        const farmersToSave = {
+        setFarmers({
           data: retrievedFarmers,
           cleanedData: cleanFarmersData(retrievedFarmers)
-        };
-        setFarmers(farmersToSave);
+        });
       })
       .catch(error => {
         console.error(error);

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,26 +1,29 @@
 /** @format */
 
-import React, { useState, useEffect } from "react";
-import { BrowserRouter as Router, Route } from "react-router-dom";
-import { Container } from "semantic-ui-react";
-import Dashboard from "../pages/Dashboard/Dashboard";
-import Login from "../pages/Login/Login";
-import AddStaff from "../pages/AddStaff/AddStaff";
-import AddFarmer from "../pages/AddFarmer/AddFarmer";
-import DisplayFarmer from "../pages/DisplayFarmer/DisplayFarmer";
-import withRestrictedAccess from "../hoc/withRestrictedAccess";
-import { getUser, logout } from "../../utils/handlers/authenticationHandlers";
+import React, { useState, useEffect } from 'react';
+import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { Container } from 'semantic-ui-react';
+import Dashboard from '../pages/Dashboard/Dashboard';
+import Login from '../pages/Login/Login';
+import AddStaff from '../pages/AddStaff/AddStaff';
+import AddFarmer from '../pages/AddFarmer/AddFarmer';
+import DisplayFarmer from '../pages/DisplayFarmer/DisplayFarmer';
+import withRestrictedAccess from '../hoc/withRestrictedAccess';
+import { getUser, logout } from '../../utils/handlers/authenticationHandlers';
 import {
   getFarmersHandler,
   cleanFarmersData
-} from "../../utils/handlers/farmerHandlers";
-import { ToastContainer } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
-import PageHeader from "../common/PageHeader/PageHeader";
+} from '../../utils/handlers/farmerHandlers';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+import PageHeader from '../common/PageHeader/PageHeader';
 
 function App() {
   const [user, setUser] = useState(undefined);
-  const [farmers, setFarmers] = useState({ data: undefined, cleanedData: undefined });
+  const [farmers, setFarmers] = useState({
+    data: undefined,
+    cleanedData: undefined
+  });
   const [needsUpdate, setNeedsUpdate] = useState(true);
 
   useEffect(() => {
@@ -39,22 +42,30 @@ function App() {
         data: undefined,
         cleanedData: undefined
       });
-      updateFarmers();
+      loadFarmers();
       setNeedsUpdate(false);
     }
   }, [user, needsUpdate]);
 
-  const updateFarmers = () => {
+  const loadFarmers = () => {
     getFarmersHandler()
       .then(retrievedFarmers => {
-        setFarmers({
+        const farmersToSave = {
           data: retrievedFarmers,
           cleanedData: cleanFarmersData(retrievedFarmers)
-        });
+        };
+        setFarmers(farmersToSave);
       })
       .catch(error => {
         console.error(error);
       });
+  };
+
+  const getFarmer = id => {
+    if (farmers.data) {
+      const farmer = farmers.data.find(farmer => farmer._id === id);
+      return farmer;
+    }
   };
 
   const logOut = () => {
@@ -75,7 +86,7 @@ function App() {
               <Dashboard
                 {...props}
                 farmers={farmers.cleanedData}
-                rawFarmers={farmers.data}
+                getFarmer={getFarmer}
               />
             )}
           />
@@ -94,7 +105,12 @@ function App() {
           <Route
             path="/farmers/:id"
             render={props => (
-              <DisplayFarmer {...props} needsUpdate={setNeedsUpdate} />
+              <DisplayFarmer
+                {...props}
+                farmers={farmers.data}
+                getFarmer={getFarmer}
+                needsUpdate={setNeedsUpdate}
+              />
             )}
           />
           <ToastContainer position="top-right" />

--- a/src/components/common/Table/Table.js
+++ b/src/components/common/Table/Table.js
@@ -5,7 +5,7 @@ import { Table } from 'semantic-ui-react';
 import styled from 'styled-components';
 
 // eslint-disable-next-line react/prop-types
-function DashboardTable({ className, history, columns, data, getFarmer }) {
+function DashboardTable({ className, history, columns, data }) {
   // Use the state and functions returned from useTable to build your UI
   const { getTableProps, headerGroups, rows, prepareRow } = useTable({
     columns,
@@ -62,7 +62,6 @@ function DashboardTable({ className, history, columns, data, getFarmer }) {
 DashboardTable.propTypes = {
   columns: PropTypes.array.isRequired,
   data: PropTypes.array.isRequired,
-  getFarmer: PropTypes.func,
   history: PropTypes.object
 };
 

--- a/src/components/common/Table/Table.js
+++ b/src/components/common/Table/Table.js
@@ -39,10 +39,7 @@ function DashboardTable({ className, history, columns, data, getFarmer }) {
               prepareRow(row) || (
                 <Table.Row
                   onClick={() => {
-                    history.push({
-                      pathname: `/farmers/${row.original.id}`,
-                      state: { farmer: getFarmer(row.original.id)}
-                    });
+                    history.push(`/farmers/${row.original.id}`);
                   }}
                   {...row.getRowProps()}
                 >

--- a/src/components/pages/Dashboard/Dashboard.js
+++ b/src/components/pages/Dashboard/Dashboard.js
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 import withRestrictedAccess from '../../hoc/withRestrictedAccess';
 import PropTypes from 'prop-types';
 
-const Dashboard = ({ farmers, getFarmer, history }) => {
+const Dashboard = ({ farmers, history }) => {
   const [data, setData] = React.useState([]);
   const Title = <Header as="h1">All Farmers</Header>;
 
@@ -71,7 +71,6 @@ const Dashboard = ({ farmers, getFarmer, history }) => {
         <StyledTable
           history={history}
           columns={columns}
-          getFarmer={getFarmer}
           data={data}
         />
       ) : (
@@ -83,7 +82,6 @@ const Dashboard = ({ farmers, getFarmer, history }) => {
 
 Dashboard.propTypes = {
   farmers: PropTypes.array,
-  rawFarmers: PropTypes.array,
   history: PropTypes.object
 };
 

--- a/src/components/pages/Dashboard/Dashboard.js
+++ b/src/components/pages/Dashboard/Dashboard.js
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 import withRestrictedAccess from '../../hoc/withRestrictedAccess';
 import PropTypes from 'prop-types';
 
-const Dashboard = ({ farmers, rawFarmers, history }) => {
+const Dashboard = ({ farmers, getFarmer, history }) => {
   const [data, setData] = React.useState([]);
   const Title = <Header as="h1">All Farmers</Header>;
 
@@ -53,11 +53,6 @@ const Dashboard = ({ farmers, rawFarmers, history }) => {
       setData([]);
     }
   }, [farmers]);
-
-  const getFarmer = id => {
-    const farmer = rawFarmers.find(farmer => farmer._id === id);
-    return farmer;
-  };
 
   return (
     <>

--- a/src/components/pages/DisplayFarmer/DisplayFarmer.js
+++ b/src/components/pages/DisplayFarmer/DisplayFarmer.js
@@ -93,7 +93,10 @@ const DisplayFarmer = ({ history, match, farmers, getFarmer, needsUpdate }) => {
 DisplayFarmer.propTypes = {
   history: PropTypes.object,
   location: PropTypes.object,
-  needsUpdate: PropTypes.func
+  needsUpdate: PropTypes.func,
+  match: PropTypes.object,
+  farmers: PropTypes.array,
+  getFarmer: PropTypes.func
 };
 
 export default withRestrictedAccess(DisplayFarmer);

--- a/src/components/pages/DisplayFarmer/DisplayFarmer.js
+++ b/src/components/pages/DisplayFarmer/DisplayFarmer.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-sequences */
 /** @format */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import withRestrictedAccess from '../../hoc/withRestrictedAccess';
 import { Container, Grid, Segment, Menu } from 'semantic-ui-react';
 import LeftDisplay from './LeftDisplay';
@@ -11,9 +11,15 @@ import FamilyTab from './FamilyTab.js';
 import FarmTab from './FarmTab';
 import GuarantorTab from './GuarantorTab.js';
 
-const DisplayFarmer = ({ history, location, needsUpdate }) => {
-  const farmer = location.state.farmer;
+const DisplayFarmer = ({ history, match, farmers, getFarmer, needsUpdate }) => {
+  const [farmer, setFarmer] = useState();
   const [selected, setSelected] = useState('Personal');
+
+  useEffect(() => {
+    const farmerId = match.params.id;
+    const farmerToSave = getFarmer(farmerId);
+    setFarmer(farmerToSave);
+  }, [farmers, getFarmer, match.params.id]);
 
   function handleSelected(e, { name }) {
     setSelected(name);
@@ -33,8 +39,8 @@ const DisplayFarmer = ({ history, location, needsUpdate }) => {
         return;
     }
   }
-
-  return (
+  return farmer ?
+   (
     <Container>
       <Grid stackable columns={2}>
         <Grid.Column width={5}>
@@ -81,7 +87,7 @@ const DisplayFarmer = ({ history, location, needsUpdate }) => {
         </Grid.Column>
       </Grid>
     </Container>
-  );
+  ) : null;
 };
 
 DisplayFarmer.propTypes = {

--- a/src/components/pages/DisplayFarmer/DisplayFarmer.js
+++ b/src/components/pages/DisplayFarmer/DisplayFarmer.js
@@ -16,9 +16,11 @@ const DisplayFarmer = ({ history, match, farmers, getFarmer, needsUpdate }) => {
   const [selected, setSelected] = useState('Personal');
 
   useEffect(() => {
-    const farmerId = match.params.id;
-    const farmerToSave = getFarmer(farmerId);
-    setFarmer(farmerToSave);
+    if (farmers) {
+      const farmerId = match.params.id;
+      const farmerToSave = getFarmer(farmerId);
+      farmerToSave ? setFarmer(farmerToSave) : history.push('/');
+    }
   }, [farmers, getFarmer, match.params.id]);
 
   function handleSelected(e, { name }) {
@@ -39,8 +41,7 @@ const DisplayFarmer = ({ history, match, farmers, getFarmer, needsUpdate }) => {
         return;
     }
   }
-  return farmer ?
-   (
+  return farmer ? (
     <Container>
       <Grid stackable columns={2}>
         <Grid.Column width={5}>


### PR DESCRIPTION
# Description

## User story

As a Tieme Ndo staff, I want to be able to open a url of a farmer on the first time I load the website.

## Motivation

There can be situations where someone loads a farmer without passing from the dashboard before, the app should be able to request that farmer data from the server if it didn’t pass using react-router.

## Finish line

- Close your browser. Open it and paste a direct url to a farmer profile
- The page should display the data normally


## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works AND the tests pass
