### PR TITLE
Fixing Update Farmer Submit on missing inputs

### DIFF
--- a/src/components/pages/UpdateFarmer/UpdateFarmer.js
+++ b/src/components/pages/UpdateFarmer/UpdateFarmer.js
@@ -121,7 +121,7 @@ const UpdateFarmer = ({ location, history, appStateShouldUpdate }) => {
     window.scrollTo(0, 75);
   };
 
-  const formHandler = async e => {
+  const formHandler = e => {
     e.preventDefault();
     let formData = {};
     const newState = JSON.parse(JSON.stringify(formElementsState));
@@ -134,7 +134,7 @@ const UpdateFarmer = ({ location, history, appStateShouldUpdate }) => {
           formData[key][key2] = newState[key][key2].selected;
         } else if (newState[key][key2].imageUrl) {
           formData[key][key2] = newState[key][key2].imageUrl;
-        } else {
+        } else { 
           formData[key][key2] = newState[key][key2].value;
         }
       }
@@ -192,7 +192,7 @@ const UpdateFarmer = ({ location, history, appStateShouldUpdate }) => {
   let farmInfoInputs = inputCreator(formElementsState.farmInfo, 'farmInfo');
 
   return (
-    <div>
+    <div data-testid='test-update-farmer-component'>
       <Segment>
         <Menu stackable widths="4">
           <Menu.Item

--- a/src/components/pages/UpdateFarmer/UpdateFarmer.js
+++ b/src/components/pages/UpdateFarmer/UpdateFarmer.js
@@ -4,8 +4,10 @@ import * as form from '../../common/Input/addFarmerData';
 import { updateFarmerHandler } from '../../../utils/handlers/farmerHandlers';
 import { getToken } from '../../../utils/handlers/authenticationHandlers';
 import withRestrictedAccess from '../../hoc/withRestrictedAccess';
+import { toast } from 'react-toastify';
 import { Menu, Segment, Form, Button } from 'semantic-ui-react';
 import axios from 'axios';
+
 const UpdateFarmer = ({ location, history, appStateShouldUpdate }) => {
   // Prevents errors when location state is empty
   const { farmer: farmerData } = location.state || {};
@@ -119,7 +121,7 @@ const UpdateFarmer = ({ location, history, appStateShouldUpdate }) => {
     window.scrollTo(0, 75);
   };
 
-  const formHandler = e => {
+  const formHandler = async e => {
     e.preventDefault();
     let formData = {};
     const newState = JSON.parse(JSON.stringify(formElementsState));
@@ -139,16 +141,24 @@ const UpdateFarmer = ({ location, history, appStateShouldUpdate }) => {
     }
 
     const token = getToken();
-    updateFarmerHandler(formData, farmerData._id, token).then(() => {
-      appStateShouldUpdate(true);
-      // removes "/edit" dynamically from the route pathname
-      history.replace(`${location.pathname.split('/edit')[0]}`, {
-        // Passes back the updated farmer data to the location state of the DisplayFarmers component
-        // Added "_id" because formData doesn't have/need an _id property
-        farmer: { ...formData, _id: farmerData._id }
-      });
-    });
+    updateFarmerHandler(formData, farmerData._id, token)
+      .then(() => {
+        appStateShouldUpdate(true);
+        // removes "/edit" dynamically from the route pathname
+        history.replace(`${location.pathname.split('/edit')[0]}`, {
+          // Passes back the updated farmer data to the location state of the DisplayFarmers component
+          // Added "_id" because formData doesn't have/need an _id property
+          farmer: { ...formData, _id: farmerData._id }
+        });
+      })
+      .catch(err => {
+        err.response.data.errors.forEach(element => {
+          toast.error(element.message);
+        });
+        return;
+      })
   };
+
   const inputCreator = (data, tabName) => {
     const formElementsArray = [];
     // eslint-disable-next-line no-unused-vars

--- a/src/utils/handlers/farmerHandlers.js
+++ b/src/utils/handlers/farmerHandlers.js
@@ -83,13 +83,12 @@ export const updateFarmerHandler = (changes, farmerId, token) => {
     setHeaders(token),
   )
     .then(res => {
-      if (res.data.successMessage) {
+      if (res.data.success) {
         return res.data;
       }
     })
-
     .catch(error => {
-      return new Error(error);
+      throw error;
     });
 };
 


### PR DESCRIPTION
# Description

Fixed a bug where the button on the Edit farmer page redirects to display farmer even if the edit wasn't successful. Now returns toasts for every error returned by the back-end.

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [x] A peer has done an informal review of my own code.
- [x] I have made corresponding changes to the documentation

