### PR TITLE
Refresh farmers data and redirect to Dashboard after successful submission of AddFarmer Form

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -123,7 +123,7 @@ function App() {
             path="/"
             exact
             isAllowed={isLoggedIn()}
-            redirectTo='/login'
+            redirectTo="/login"
             render={props => (
               <Dashboard
                 {...props}
@@ -135,7 +135,7 @@ function App() {
           <RestrictedRoute
             path="/accounts/new"
             isAllowed={isLoggedIn() && getUser().isAdmin}
-            redirectTo='/'
+            redirectTo="/"
             component={AddStaff}
           />
           <Route
@@ -145,7 +145,7 @@ function App() {
           <RestrictedRoute
             path="/farmers/:id/edit"
             isAllowed={isLoggedIn()}
-            redirectTo='/login'
+            redirectTo="/login"
             render={props => (
               <UpdateFarmer
                 {...props}
@@ -157,14 +157,19 @@ function App() {
           <RestrictedRoute
             path="/addfarmer"
             isAllowed={isLoggedIn()}
-            redirectTo='/login'
-            component={AddFarmer}
+            redirectTo="/login"
+            render={props => (
+              <AddFarmer
+                {...props}
+                appStateShouldUpdate={setNeedsUpdate}
+              />
+            )}
           />
           <RestrictedRoute
             exact
             path="/farmers/:id"
             isAllowed={isLoggedIn()}
-            redirectTo='/login'
+            redirectTo="/login"
             render={props => (
               <DisplayFarmer
                 {...props}
@@ -178,14 +183,14 @@ function App() {
             exact
             path="/reset-password"
             isAllowed={isLoggedIn()}
-            redirectTo='/login'
+            redirectTo="/login"
             render={props => <PasswordReset {...props} logOut={logOut} />}
           />
           <RestrictedRoute
             exact
             path="/edit-collection/:id"
             isAllowed={isLoggedIn() && getUser().isAdmin}
-            redirectTo='/login'
+            redirectTo="/login"
             render={props => (
               <EditCollection
                 {...props}

--- a/src/components/pages/AddFarmer/AddFarmer.js
+++ b/src/components/pages/AddFarmer/AddFarmer.js
@@ -15,7 +15,7 @@ import { setHeaders } from '../../../utils/requestHeaders';
 import { toast } from 'react-toastify';
 import { Menu, Segment, Form, Button } from 'semantic-ui-react';
 
-const AddFarmer = () => {
+const AddFarmer = ({ history, appStateShouldUpdate }) => {
   const [state, setState] = useState({});
 
   const defaultState = () => {
@@ -149,8 +149,9 @@ const AddFarmer = () => {
       .post(`${pathObj.addFarmerPath}/create`, formData, setHeaders(getToken()))
       .then(res => {
         toast.success('Farmer Added Successfully');
+        appStateShouldUpdate(true);
         defaultState();
-        return;
+        history.push('/');
       })
       .catch(err => {
         err.response.data.errors.forEach(element => {

--- a/src/utils/handlers/changeRequestHandler.js
+++ b/src/utils/handlers/changeRequestHandler.js
@@ -64,7 +64,7 @@ export const rejectChangeRequest = (
 ) => {
   const token = getToken();
   return axios
-    .post(`${pathObj.getEdits}/${requestId}/approve`, {}, setHeaders(token))
+    .post(`${pathObj.getEdits}/${requestId}/decline`, {}, setHeaders(token))
     .then(res => {
       if (res.data) {
         toast.success('Farmer record rejected');


### PR DESCRIPTION
# Description

## Motivation
It's bad UX when you add a farmer and you don't see it appear until you refresh the whole page. 

## Finish line
- After you add a new farmer you can see it right away, redirecting to dashboard or redirecting to the new farmer page.

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
