### PR TITLE
Add toast on duplicate farmer submission

### DIFF
--- a/src/components/pages/AddFarmer/AddFarmer.js
+++ b/src/components/pages/AddFarmer/AddFarmer.js
@@ -154,10 +154,12 @@ const AddFarmer = ({ history, appStateShouldUpdate }) => {
         history.push('/');
       })
       .catch(err => {
-        err.response.data.errors.forEach(element => {
-          toast.error(element.message);
-        });
-        return;
+        if (Array.isArray(err.response.data.errors)) {
+          err.response.data.errors.forEach(element => {
+            toast.error(element.message);
+          });
+        }
+        toast.error(err.response.data.errors.message)
       });
   };
   const inputCreator = (data, tabName) => {


### PR DESCRIPTION
# Description

This solves https://trello.com/c/AC3NZVAY/158-submitting-an-already-exiting-farmer-does-not-create-a-notification-toast. 

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works AND the tests pass
