### PR TITLE
Avoid re-render when clicking the bell in  "Display Farmer" and "Add farmer" components

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -116,11 +116,7 @@ function App() {
           />
         ) : null}
 
-        <Container
-          onClick={() => {
-            console.log("Close panel");
-          }}
-        >
+        <Container id="container">
           <RestrictedRoute
             path="/"
             exact

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -140,7 +140,6 @@ function App() {
               <Dashboard
                 {...props}
                 farmers={data.farmersDashboard}
-                getFarmer={getFarmer}
                 statistics={data.statistics}
               />
             )}
@@ -180,14 +179,23 @@ function App() {
             path="/farmers/:id"
             isAllowed={isLoggedIn()}
             redirectTo="/login"
-            render={props => (
-              <DisplayFarmer
-                {...props}
-                farmers={data.farmers}
-                getFarmer={getFarmer}
-                needsUpdate={setNeedsUpdate}
-              />
-            )}
+            render={props => {
+              const id = props.match.params.id;
+              let selectedFarmer;
+              if (data.farmers) {
+                selectedFarmer = getFarmer(id);
+                if (!selectedFarmer) selectedFarmer = null;
+              }
+
+              return (
+                <DisplayFarmer
+                  {...props}
+                  farmer={selectedFarmer}
+                  getFarmer={getFarmer}
+                  needsUpdate={setNeedsUpdate}
+                />
+              );
+            }}
           />
           <RestrictedRoute
             exact

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -37,7 +37,6 @@ function App() {
   });
   const [needsUpdate, setNeedsUpdate] = useState(true);
   const [changeRequest, setChangeRequest] = useState([]);
-  const [visible, setVisible] = useState(false);
 
   const loadFarmers = useCallback(() => {
     getFarmersHandler()
@@ -106,16 +105,6 @@ function App() {
       });
   };
 
-  const closeSideBar = () => {
-    if (visible) {
-      setVisible(!visible);
-    }
-  };
-
-  const toggleSideBar = () => {
-    setVisible(!visible);
-  };
-
   return (
     <Router>
       <div className="App" data-testid="App">
@@ -124,13 +113,14 @@ function App() {
             logOut={logOut}
             user={user}
             edits={changeRequest}
-            visible={visible}
-            closeSideBar={closeSideBar}
-            toggleSideBar={toggleSideBar}
           />
         ) : null}
 
-        <Container onClick={closeSideBar}>
+        <Container
+          onClick={() => {
+            console.log("Close panel");
+          }}
+        >
           <RestrictedRoute
             path="/"
             exact

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -177,7 +177,6 @@ function App() {
                 <DisplayFarmer
                   {...props}
                   farmer={selectedFarmer}
-                  getFarmer={getFarmer}
                   needsUpdate={setNeedsUpdate}
                 />
               );

--- a/src/components/common/PageHeader/PageHeader.js
+++ b/src/components/common/PageHeader/PageHeader.js
@@ -28,6 +28,15 @@ const PageHeader = ({ logOut, user, edits }) => {
   const toggleSideBar = () => {
     setVisible(!visible);
   };
+
+  React.useEffect(function setupListener() {
+    window.addEventListener('click', closeSideBar)
+
+    return function cleanupListener() {
+      window.removeEventListener('click', closeSideBar)
+    }
+
+  })
   return (
     <div data-testid="nav-test">
       <Menu

--- a/src/components/common/PageHeader/PageHeader.js
+++ b/src/components/common/PageHeader/PageHeader.js
@@ -30,13 +30,13 @@ const PageHeader = ({ logOut, user, edits }) => {
   };
 
   React.useEffect(function setupListener() {
-    window.addEventListener('click', closeSideBar)
+    window.addEventListener('click', closeSideBar);
 
     return function cleanupListener() {
-      window.removeEventListener('click', closeSideBar)
-    }
+      window.removeEventListener('click', closeSideBar);
+    };
+  });
 
-  })
   return (
     <div data-testid="nav-test">
       <Menu

--- a/src/components/common/PageHeader/PageHeader.js
+++ b/src/components/common/PageHeader/PageHeader.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -16,14 +16,18 @@ const Span = styled.span`
   }
 `;
 
-const PageHeader = ({
-  logOut,
-  user,
-  edits,
-  visible,
-  closeSideBar,
-  toggleSideBar
-}) => {
+const PageHeader = ({ logOut, user, edits }) => {
+  const [visible, setVisible] = useState(false);
+
+  const closeSideBar = () => {
+    if (visible) {
+      setVisible(!visible);
+    }
+  };
+
+  const toggleSideBar = () => {
+    setVisible(!visible);
+  };
   return (
     <div data-testid="nav-test">
       <Menu

--- a/src/components/pages/DisplayFarmer/DisplayFarmer.js
+++ b/src/components/pages/DisplayFarmer/DisplayFarmer.js
@@ -10,18 +10,15 @@ import FamilyTab from './FamilyTab.js';
 import FarmTab from './FarmTab';
 import GuarantorTab from './GuarantorTab.js';
 
-const DisplayFarmer = ({ history, match, farmers, getFarmer, needsUpdate }) => {
-  const [farmer, setFarmer] = useState();
+const DisplayFarmer = ({ history, farmer, needsUpdate }) => {
   const [selected, setSelected] = useState('Personal');
 
   useEffect(() => {
-    if (farmers) {
-      const farmerId = match.params.id;
-      const farmerToSave = getFarmer(farmerId);
-      farmerToSave ? setFarmer(farmerToSave) : history.push('/');
+    if (farmer === null) {
+      history.push('/');
     }
-  }, [farmers, getFarmer, match.params.id, history]);
- 
+  }, [farmer, history]);
+
   function handleSelected(e, { name }) {
     setSelected(name);
   }
@@ -94,11 +91,8 @@ const DisplayFarmer = ({ history, match, farmers, getFarmer, needsUpdate }) => {
 
 DisplayFarmer.propTypes = {
   history: PropTypes.object,
-  location: PropTypes.object,
   needsUpdate: PropTypes.func,
-  match: PropTypes.object,
-  farmers: PropTypes.array,
-  getFarmer: PropTypes.func
+  farmer: PropTypes.object,
 };
 
 export default DisplayFarmer;

--- a/src/components/pages/DisplayFarmer/__tests__/DisplayFarmer.test.js
+++ b/src/components/pages/DisplayFarmer/__tests__/DisplayFarmer.test.js
@@ -45,7 +45,7 @@ it('renders without crashing', () => {
 
   const { getByTestId } = render(
     <Router>
-      <DisplayFarmer getFarmer={getFarmer} farmers={farmers} match={match} />
+      <DisplayFarmer farmer={farmers[0]} match={match} />
     </Router>
   );
 
@@ -62,7 +62,7 @@ it('renders the respective tab when clicking tab link', () => {
 
   const { getByTestId } = render(
     <Router>
-      <DisplayFarmer getFarmer={getFarmer} farmers={farmers} match={match} />
+      <DisplayFarmer farmer={farmers[0]} match={match} />
     </Router>
   );
 


### PR DESCRIPTION
# Description

When clicking on the notification bell a whole rerender occurs that makes the components reload the page. Improve the display to use passed props instead of requiring so many states inside of components.

## Checklist

Remove any items which are not applicable.

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works AND the tests pass
