### PR TITLE
Change Toasts Positioning + Remove Progress Bar

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -21,7 +21,8 @@ import {
   getFarmersHandler,
   cleanFarmersData
 } from '../../utils/handlers/farmerHandlers';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
+import { StyledToastContainer } from '../common/Toast/StyledToastContainer';
 import 'react-toastify/dist/ReactToastify.css';
 import PageHeader from '../common/PageHeader/PageHeader';
 import EditCollection from '../pages/EditCollection/EditCollection';
@@ -209,10 +210,9 @@ function App() {
             )}
           />
 
-          <ToastContainer
+          <StyledToastContainer
             position="top-right"
             hideProgressBar
-            style={{ top: '64px' }}
           />
         </Container>
       </div>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -209,7 +209,11 @@ function App() {
             )}
           />
 
-          <ToastContainer position="top-right" />
+          <ToastContainer
+            position="top-right"
+            hideProgressBar
+            style={{ top: '64px' }}
+          />
         </Container>
       </div>
     </Router>

--- a/src/components/common/Toast/StyledToastContainer.js
+++ b/src/components/common/Toast/StyledToastContainer.js
@@ -1,0 +1,11 @@
+import { ToastContainer } from 'react-toastify';
+import styled from 'styled-components';
+
+export const StyledToastContainer = styled(ToastContainer)`
+  &.Toastify__toast-container {
+    top: 64px;
+    .Toastify__toast {
+      border-radius: 4px;
+    }
+  }
+`;


### PR DESCRIPTION
# Description

Moving the `Toasts` container down by `64px;`, removing its progress bar + adding border-radius to toasts.

## Checklist

- [x] I have performed a self-review of my own code
