### PR TITLE
Remove warning logs from frontend tests

### DIFF
--- a/src/components/pages/EditCollection/EditCollection.js
+++ b/src/components/pages/EditCollection/EditCollection.js
@@ -11,6 +11,7 @@ import {
   approveChangeRequest,
   rejectChangeRequest
 } from '../../../utils/handlers/changeRequestHandler';
+import { toast } from 'react-toastify';
 
 const Div = styled.div`
   strike {
@@ -60,6 +61,9 @@ const EditCollection = ({ match, history, appStateShouldUpdate }) => {
         });
       })
       .catch(() => {
+        toast.error(
+          'Network Error when retrieving change request. Redirecting to Dashboard'
+        );
         // If no request is found with that ID
         history.push('/');
       });

--- a/src/components/pages/EditCollection/EditCollection.js
+++ b/src/components/pages/EditCollection/EditCollection.js
@@ -6,7 +6,6 @@ import styled from 'styled-components';
 import uuid from 'uuid';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { toast } from 'react-toastify';
 import {
   getChangeRequestById,
   approveChangeRequest,
@@ -60,7 +59,10 @@ const EditCollection = ({ match, history, appStateShouldUpdate }) => {
           };
         });
       })
-      .catch(err => toast.error(err.message));
+      .catch(() => {
+        // If no request is found with that ID
+        history.push('/');
+      });
   }, [match]);
 
   const { data, cleanedData } = state;

--- a/src/components/pages/EditCollection/EditCollection.js
+++ b/src/components/pages/EditCollection/EditCollection.js
@@ -63,7 +63,7 @@ const EditCollection = ({ match, history, appStateShouldUpdate }) => {
         // If no request is found with that ID
         history.push('/');
       });
-  }, [match]);
+  }, [match, history]);
 
   const { data, cleanedData } = state;
 

--- a/src/utils/handlers/changeRequestHandler.js
+++ b/src/utils/handlers/changeRequestHandler.js
@@ -29,7 +29,7 @@ export const getChangeRequestById = requestId => {
       }
     })
     .catch(error => {
-      return new Error(error);
+      throw new Error(error.response.data.message);
     });
 };
 


### PR DESCRIPTION
This fixes the way that the handler was throwing the error, which somehow was generating all the unrelated warning logs in the tests.

It also redirects to the dashboard if the changeRequest ID can't be found instead of displaying errors.

## Checklist

Remove any items which are not applicable.

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works AND the tests pass
